### PR TITLE
release: Add GitHub Action for publish a release on PS Gallery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on: [release]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    secrets: ["PSGALLERY_API_KEY"]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish
+      run: |
+        pwsh -Command "Publish-Module -Path ./PowerArubaCP -NuGetApiKey $Env:PSGALLERY_API_KEY"


### PR DESCRIPTION
When create a new releae on GitHub automatically push a new release on PS Gallery