### PR TITLE
Add port parameter for Connect-ArubaCP

### DIFF
--- a/PowerArubaCP/Private/RestMethod.ps1
+++ b/PowerArubaCP/Private/RestMethod.ps1
@@ -75,9 +75,10 @@ function Invoke-ArubaCPRestMethod {
             Throw "Not Connected. Connect to the ClearPass with Connect-ArubaCP"
         }
 
+        $port = $connection.port
         $Server = $connection.Server
         $invokeParams = $connection.invokeParams
-        $fullurl = "https://${Server}/${uri}"
+        $fullurl = "https://${Server}:${port}/${uri}"
 
         if ($fullurl -NotMatch "\?") {
             $fullurl += "?"

--- a/PowerArubaCP/Public/Connection.ps1
+++ b/PowerArubaCP/Public/Connection.ps1
@@ -43,6 +43,9 @@ function Connect-ArubaCP {
         [Parameter(Mandatory = $false)]
         [switch]$SkipCertificateCheck = $false,
         [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 65535)]
+        [int]$port = 443,
+        [Parameter(Mandatory = $false)]
         [boolean]$DefaultConnection = $true
     )
 
@@ -51,7 +54,7 @@ function Connect-ArubaCP {
 
     Process {
 
-        $connection = @{server = ""; token = ""; invokeParams = "" ; version = "" }
+        $connection = @{server = ""; token = ""; invokeParams = "" ; version = "" ; port = $port }
         $invokeParams = @{DisableKeepAlive = $false; UseBasicParsing = $true; SkipCertificateCheck = $SkipCertificateCheck }
 
         if ("Desktop" -eq $PSVersionTable.PsEdition) {

--- a/PowerArubaCP/Public/Connection.ps1
+++ b/PowerArubaCP/Public/Connection.ps1
@@ -24,6 +24,11 @@ function Connect-ArubaCP {
       Connect to an Aruba ClearPass using HTTPS (without check certificate validation) with IP 192.0.2.1 using token aaaaaaa
 
       .EXAMPLE
+      Connect-ArubaCP -Server 192.0.2.1 -token aaaaaaaaaaaaa -port 4443
+
+      Connect to an Aruba ClearPass with IP 192.0.2.1 using token aaaaaaa on port 4443
+
+      .EXAMPLE
       $cppm1 = Connect-ArubaCP -Server 192.0.2.1 -token aaaaaaaaaaaaa
 
       Connect to an ArubaOS ClaerPass with IP 192.0.2.1 and store connection info to $cppm1 variable

--- a/Tests/common.ps1
+++ b/Tests/common.ps1
@@ -4,15 +4,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if ("Desktop" -eq $PSVersionTable.PsEdition) { # -BeOfType is not same on PowerShell Core and Desktop (get int with Desktop and long with Core for number)
+if ("Desktop" -eq $PSVersionTable.PsEdition) {
+    # -BeOfType is not same on PowerShell Core and Desktop (get int with Desktop and long with Core for number)
     $script:pester_longint = "int"
 }
 else {
     $script:pester_longint = "long"
 }
 
+if ($port) {
+    $script:port = "443"
+}
+
 . ../credential.ps1
 #TODO: Add check if no ipaddress/token info...
 
-Connect-ArubaCP -Server $ipaddress -Token $token -SkipCertificateCheck
+Connect-ArubaCP -Server $ipaddress -port $port -Token $token -SkipCertificateCheck
 

--- a/Tests/credential.example.ps1
+++ b/Tests/credential.example.ps1
@@ -9,6 +9,9 @@
 $script:ipaddress = "10.44.23.213"
 $script:token = "aaaaaaaaaaaaaaaaaa"
 
+#Uncomment if you want to use another port to access to ClearPass
+#script:port = "443"
+
 #Uncomment if you want to enable add and Remove Application License (recommended to use Onboard license for test...)
 #$script:pester_license_type = "Onboard"
 #$script:pester_license = "

--- a/Tests/integration/Connection.Tests.ps1
+++ b/Tests/integration/Connection.Tests.ps1
@@ -11,10 +11,11 @@ Describe  "Connect to a ClearPass (using Token)" {
         Disconnect-ArubaCP -noconfirm
     }
     It "Connect to ClearPass (using Token) and check global variable" {
-        Connect-ArubaCP $ipaddress -Token $token -SkipCertificateCheck
+        Connect-ArubaCP $ipaddress -Token $token -port $port -SkipCertificateCheck
         $DefaultArubaCPConnection | Should Not BeNullOrEmpty
         $DefaultArubaCPConnection.server | Should be $ipaddress
         $DefaultArubaCPConnection.token | Should be $token
+        $DefaultArubaCPConnection.port | Should be $port
     }
     It "Disconnect to ClearPass and check global variable" {
         Disconnect-ArubaCP -noconfirm
@@ -25,7 +26,7 @@ Describe  "Connect to a ClearPass (using Token)" {
     #This test only work with PowerShell 6 / Core (-SkipCertificateCheck don't change global variable but only Invoke-WebRequest/RestMethod)
     #This test will be fail, if there is valid certificate...
     It "Throw when try to use Connect-ArubaCP  with don't use -SkipCertifiateCheck" -Skip:("Desktop" -eq $PSEdition) {
-        { Connect-ArubaCP $ipaddress -Token $token } | Should throw "Unable to connect (certificate)"
+        { Connect-ArubaCP $ipaddress -Token $token -port $port } | Should throw "Unable to connect (certificate)"
         Disconnect-ArubaCP -noconfirm
     }
     It "Throw when try to use Invoke-ArubaCPRestMethod and not connected" {
@@ -39,10 +40,11 @@ Describe  "Connect to a ClearPass (using multi connection)" {
         Disconnect-ArubaCP -noconfirm
     }
     It "Connect to a ClearPass (using token and store on cppm variable)" {
-        $script:cppm = Connect-ArubaCP $ipaddress -Token $token -SkipCertificateCheck -DefaultConnection:$false
+        $script:cppm = Connect-ArubaCP $ipaddress -Token $token -SkipCertificateCheck -port $port -DefaultConnection:$false
         $DefaultArubaCPConnection | Should -BeNullOrEmpty
         $cppm.server | Should be $ipaddress
         $cppm.token | Should be $token
+        $cppm.port | Should be $port
     }
 
     Context "Use Multi connection for call some (Get) cmdlet (Vlan, System...)" {
@@ -76,7 +78,7 @@ Describe  "Connect to a ClearPass (using multi connection)" {
 Describe  "Invoke ArubaCP RestMethod tests" {
     BeforeAll {
         #connect...
-        Connect-ArubaCP $ipaddress -Token $token -SkipCertificateCheck
+        Connect-ArubaCP $ipaddress -Token $token -SkipCertificateCheck -port $port
         #Add 26 Network Device (NAS)
         Add-ArubaCPNetworkDevice -name pester_SW1 -ip_address 192.0.2.1 -radius_secret MySecurePassword -vendor Aruba
         Add-ArubaCPNetworkDevice -name pester_SW2 -ip_address 192.0.2.2 -radius_secret MySecurePassword -vendor Aruba


### PR DESCRIPTION
Also update Invoke-ArubaCPRestMethod to use this parameter
You can now connect to ClearPass don't use port 443 (between a reverse proxy..)