### PR TITLE
PSSA: Add missing mark for SuppressMessageAttribute

### DIFF
--- a/PowerArubaCP/Public/ApplicationLicense.ps1
+++ b/PowerArubaCP/Public/ApplicationLicense.ps1
@@ -84,7 +84,7 @@ function Get-ArubaCPApplicationLicense {
 
     #>
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter")] #False positive see https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", '')] #False positive see https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
     [CmdLetBinding(DefaultParameterSetName = "Default")]
 
     Param(

--- a/PowerArubaCP/Public/Platform.ps1
+++ b/PowerArubaCP/Public/Platform.ps1
@@ -59,7 +59,7 @@ function Get-ArubaCPServerConfiguration {
 
     #>
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter")] #False positive see https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", '')] #False positive see https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
     [CmdLetBinding(DefaultParameterSetName = "Default")]
 
     Param(


### PR DESCRIPTION
For avoid Cannot find an overload for '.ctor' and the argument count: '1'.