### PR TITLE
Fix Typo on Application License and Endpoint

### DIFF
--- a/PowerArubaCP/Public/ApplicationLicense.ps1
+++ b/PowerArubaCP/Public/ApplicationLicense.ps1
@@ -21,10 +21,10 @@ function Add-ArubaCPApplicationLicense {
     #>
 
     Param(
-        [Parameter (Mandatory = $false)]
+        [Parameter (Mandatory = $true)]
         [ValidateSet('Access', 'Access Upgrade', 'Entry', 'Onboard', 'OnGuard', IgnoreCase = $false)]
         [string]$product_name,
-        [Parameter (Mandatory = $false)]
+        [Parameter (Mandatory = $true)]
         [string]$license_key,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]

--- a/PowerArubaCP/Public/ApplicationLicense.ps1
+++ b/PowerArubaCP/Public/ApplicationLicense.ps1
@@ -16,7 +16,7 @@ function Add-ArubaCPApplicationLicense {
         .EXAMPLE
         Add-ArubaCPApplicationLicense -product_name Access -license_key XXXXXXX
 
-        Add a Application license type Access with license key XXXXXXX
+        Add an Application license type Access with license key XXXXXXX
 
     #>
 

--- a/PowerArubaCP/Public/Endpoint.ps1
+++ b/PowerArubaCP/Public/Endpoint.ps1
@@ -11,7 +11,7 @@ function Add-ArubaCPEndpoint {
         Add an Endpoint on ClearPass
 
         .DESCRIPTION
-        Add an Endoint with mac address, description, status, attributes
+        Add an Enpdoint with mac address, description, status, attributes
 
         .EXAMPLE
         Add-ArubaCPEndpoint -mac_address 000102030405 -description "Add by PowerArubaCP" -Status Known
@@ -84,7 +84,7 @@ function Get-ArubaCPEndpoint {
 
     <#
         .SYNOPSIS
-        Get Enpoint info on CPPM
+        Get Endpoint info on CPPM
 
         .DESCRIPTION
         Get Endpoint (Id, MAC Address, Status, Attributes)
@@ -316,12 +316,12 @@ function Remove-ArubaCPEndpoint {
         $ep = Get-ArubaCPEndpoint -mac_address 00:01:02:03:04:05
         PS C:\>$ep | Remove-ArubaCPEndpoint
 
-        Remove Endpoint with MAC Address 00:01:02:03:04:05
+        Remove an Endpoint with MAC Address 00:01:02:03:04:05
 
         .EXAMPLE
         Remove-ArubaCPEndpoint -id 3001 -confirm:$false
 
-        Remove Endpoint with id 3001 and no confirmation
+        Remove an Endpoint with id 3001 and no confirmation
     #>
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]

--- a/PowerArubaCP/Public/Endpoint.ps1
+++ b/PowerArubaCP/Public/Endpoint.ps1
@@ -349,7 +349,7 @@ function Remove-ArubaCPEndpoint {
 
         $uri = "api/endpoint/${id}"
 
-        if ($PSCmdlet.ShouldProcess("$id + $mac", 'Remove Endpoint')) {
+        if ($PSCmdlet.ShouldProcess("$id $mac", 'Remove Endpoint')) {
             Invoke-ArubaCPRestMethod -method "DELETE" -uri $uri -connection $connection
         }
 


### PR DESCRIPTION
- Missing mandatory field (product_name and license_key) when Add
- typo on example (a -> an)
- typo on endpoint (missing d)