### PR TITLE
NetworkDevice (NAD):  Allow SNMP parameters

### DIFF
--- a/PowerArubaCP/Public/NetworkDevice.ps1
+++ b/PowerArubaCP/Public/NetworkDevice.ps1
@@ -140,7 +140,7 @@ function Add-ArubaCPNetworkDevice {
                 throw "If snmp_version is specified, community_string is mandatory."
             }
             $snmp_read = @{
-                snmp_version = $snmp_version
+                snmp_version = $snmp_version.ToUpper()
                 community_string = $community_string
                 zone_name = "default"
             }
@@ -385,7 +385,7 @@ function Set-ArubaCPNetworkDevice {
                 throw "If snmp_version is specified, community_string is mandatory."
             }
             $snmp_read = @{
-                snmp_version = $snmp_version
+                snmp_version = $snmp_version.ToUpper()
                 community_string = $community_string
                 zone_name = "default"
             }

--- a/PowerArubaCP/Public/NetworkDevice.ps1
+++ b/PowerArubaCP/Public/NetworkDevice.ps1
@@ -24,11 +24,6 @@ function Add-ArubaCPNetworkDevice {
         Add Network Device SW2 with COA Capability on port 5000
 
         .EXAMPLE
-        Add-ArubaCPNetworkDevice -name SW3 -ip_address 192.0.2.3 -radius_secret MySecurePassword -vendor Cisco -snmp_version V2C -community_string CommString
-
-        Add Network Device SW3 with a snmp-read community string from vendor Cisco
-
-        .EXAMPLE
         Add-ArubaCPNetworkDevice -name SW3 -ip_address 192.0.2.3 -radius_secret MySecurePassword -vendor Cisco -tacacs_secret MySecurePassword
 
         Add Network Device SW3 with a tacacs secret from vendor Cisco
@@ -43,6 +38,11 @@ function Add-ArubaCPNetworkDevice {
         PS > Add-ArubaCPNetworkDevice -name SW5 -ip_address 192.0.2.5 -radius_secret MySecurePassword -vendor Aruba -attributes $attributes
 
         Add Network Device SW5 with hashtable attribute (Location) from vendor Aruba
+
+        .EXAMPLE
+        Add-ArubaCPNetworkDevice -name SW6 -ip_address 192.0.2.6 -radius_secret MySecurePassword -vendor Cisco -snmp_version V2C -community_string CommString
+
+        Add Network Device SW6 with a snmp-read community string from vendor Cisco
 
     #>
 

--- a/PowerArubaCP/Public/NetworkDevice.ps1
+++ b/PowerArubaCP/Public/NetworkDevice.ps1
@@ -24,6 +24,11 @@ function Add-ArubaCPNetworkDevice {
         Add Network Device SW2 with COA Capability on port 5000
 
         .EXAMPLE
+        Add-ArubaCPNetworkDevice -name SW3 -ip_address 192.0.2.3 -radius_secret MySecurePassword -vendor Cisco -snmp_version V2C -community_string CommString
+
+        Add Network Device SW3 with a snmp-read community string from vendor Cisco
+
+        .EXAMPLE
         Add-ArubaCPNetworkDevice -name SW3 -ip_address 192.0.2.3 -radius_secret MySecurePassword -vendor Cisco -tacacs_secret MySecurePassword
 
         Add Network Device SW3 with a tacacs secret from vendor Cisco
@@ -52,6 +57,10 @@ function Add-ArubaCPNetworkDevice {
         [ipaddress]$ip_address,
         [Parameter (Mandatory = $true)]
         [string]$radius_secret,
+        [Parameter (Mandatory = $false)]
+        [string]$snmp_version,
+        [Parameter (Mandatory = $false)]
+        [string]$community_string,
         [Parameter (Mandatory = $false)]
         [string]$tacacs_secret,
         [Parameter (Mandatory = $true)]
@@ -122,6 +131,15 @@ function Add-ArubaCPNetworkDevice {
 
         if ( $PsBoundParameters.ContainsKey('attributes') ) {
             $_nad | add-member -name "attributes" -membertype NoteProperty -Value $attributes
+        }
+
+        if ($PsBoundParameters.ContainsKey('snmp_version')) {
+            $snmp_read = @{
+            snmp_version = $snmp_version
+            community_string = $community_string
+            zone_name = "default"
+            }
+            $_nad | add-member -name "snmp_read" -membertype NoteProperty -Value $snmp_read
         }
 
         $nad = invoke-ArubaCPRestMethod -method "POST" -body $_nad -uri $uri -connection $connection
@@ -275,6 +293,12 @@ function Set-ArubaCPNetworkDevice {
 
         .EXAMPLE
         $nad = Get-ArubaCPNetworkDevice -name NAD-PowerArubaCP
+        PS > $nad | Set-ArubaCPNetworkDevice -snmp_version V2C -community_string MyComm
+
+        Set SNMP version and community string of NAD-PowerArubaCP
+
+        .EXAMPLE
+        $nad = Get-ArubaCPNetworkDevice -name NAD-PowerArubaCP
         PS > $nad | Set-ArubaCPNetworkDevice -coa_capable -coa_port 5000
 
         Enable COA and set COA Port to 5000 of NAD-PowerArubaCP
@@ -296,6 +320,10 @@ function Set-ArubaCPNetworkDevice {
         [ipaddress]$ip_address,
         [Parameter (Mandatory = $false)]
         [string]$radius_secret,
+        [Parameter (Mandatory = $false)]
+        [string]$snmp_version,
+        [Parameter (Mandatory = $false)]
+        [string]$community_string,
         [Parameter (Mandatory = $false)]
         [string]$tacacs_secret,
         [Parameter (Mandatory = $false)]
@@ -344,6 +372,16 @@ function Set-ArubaCPNetworkDevice {
         if ( $PsBoundParameters.ContainsKey('radius_secret') ) {
             $_nad | add-member -name "radius_secret" -membertype NoteProperty -Value $radius_secret
         }
+
+        if ($PsBoundParameters.ContainsKey('snmp_version')) {
+            $snmp_read = @{
+            snmp_version = $snmp_version
+            community_string = $community_string
+            zone_name = "default"
+            }
+            $_nad | add-member -name "snmp_read" -membertype NoteProperty -Value $snmp_read
+        }
+
 
         if ( $PsBoundParameters.ContainsKey('tacacs_secret') ) {
             $_nad | add-member -name "tacacs_secret" -membertype NoteProperty -Value $tacacs_secret

--- a/PowerArubaCP/Public/NetworkDevice.ps1
+++ b/PowerArubaCP/Public/NetworkDevice.ps1
@@ -58,6 +58,7 @@ function Add-ArubaCPNetworkDevice {
         [Parameter (Mandatory = $true)]
         [string]$radius_secret,
         [Parameter (Mandatory = $false)]
+        [ValidateSet('v1', 'v2c')]
         [string]$snmp_version,
         [Parameter (Mandatory = $false)]
         [string]$community_string,
@@ -134,10 +135,14 @@ function Add-ArubaCPNetworkDevice {
         }
 
         if ($PsBoundParameters.ContainsKey('snmp_version')) {
+            # Check if snmp_version is provided, and if so, make community_string mandatory
+            if (-not $PsBoundParameters.ContainsKey('community_string')) {
+                throw "If snmp_version is specified, community_string is mandatory."
+            }
             $snmp_read = @{
-            snmp_version = $snmp_version
-            community_string = $community_string
-            zone_name = "default"
+                snmp_version = $snmp_version
+                community_string = $community_string
+                zone_name = "default"
             }
             $_nad | add-member -name "snmp_read" -membertype NoteProperty -Value $snmp_read
         }
@@ -321,6 +326,7 @@ function Set-ArubaCPNetworkDevice {
         [Parameter (Mandatory = $false)]
         [string]$radius_secret,
         [Parameter (Mandatory = $false)]
+        [ValidateSet('v1', 'v2c')]
         [string]$snmp_version,
         [Parameter (Mandatory = $false)]
         [string]$community_string,
@@ -374,10 +380,14 @@ function Set-ArubaCPNetworkDevice {
         }
 
         if ($PsBoundParameters.ContainsKey('snmp_version')) {
+            # Check if snmp_version is provided, and if so, make community_string mandatory
+            if (-not $PsBoundParameters.ContainsKey('community_string')) {
+                throw "If snmp_version is specified, community_string is mandatory."
+            }
             $snmp_read = @{
-            snmp_version = $snmp_version
-            community_string = $community_string
-            zone_name = "default"
+                snmp_version = $snmp_version
+                community_string = $community_string
+                zone_name = "default"
             }
             $_nad | add-member -name "snmp_read" -membertype NoteProperty -Value $snmp_read
         }

--- a/Tests/integration/NetworkDevice.Tests.ps1
+++ b/Tests/integration/NetworkDevice.Tests.ps1
@@ -403,6 +403,60 @@ Describe "Remove Network Device" {
 
 }
 
+Describe "Add Network Device" {
+
+    It "Add Network Device with snmp v2c" {
+        Add-ArubaCPNetworkDevice -name pester_SW6 -ip_address 192.0.2.6 -radius_secret MySecurePassword -vendor Cisco -snmp_version v2c -community_string myString
+        $nad = Get-ArubaCPNetworkDevice -name pester_SW6
+        $nad.name | Should -Be "pester_SW6"
+        $nad.ip_address | Should -Be "192.0.2.6"
+        $nad.vendor_name | Should -Be "Cisco"
+        $nad.snmp_read.snmp_version | Should -Be "v2c"
+        $nad.snmp_read.zone_name | Should -Be "default"
+        # community_string is always empty
+    }
+
+    It "Add Network Device with snmp v1" {
+        Add-ArubaCPNetworkDevice -name pester_SW6 -ip_address 192.0.2.6 -radius_secret MySecurePassword -vendor Cisco -snmp_version v1 -community_string myString
+        $nad = Get-ArubaCPNetworkDevice -name pester_SW6
+        $nad.name | Should -Be "pester_SW6"
+        $nad.ip_address | Should -Be "192.0.2.6"
+        $nad.vendor_name | Should -Be "Cisco"
+        $nad.snmp_read.snmp_version | Should -Be "v1"
+        $nad.snmp_read.zone_name | Should -Be "default"
+        # community_string is always empty
+    }
+
+    It "Add Network Device with snmp v2c then change it to v1" {
+        Add-ArubaCPNetworkDevice -name pester_SW6 -ip_address 192.0.2.6 -radius_secret MySecurePassword -vendor Cisco -snmp_version v2c -community_string myString
+        Get-ArubaCPNetworkDevice -name pester_SW6 | Set-ArubaCPNetworkDevice -snmp_version v1 -community_string myString
+        $nad = Get-ArubaCPNetworkDevice -name pester_SW6
+        $nad.name | Should -Be "pester_SW6"
+        $nad.ip_address | Should -Be "192.0.2.6"
+        $nad.vendor_name | Should -Be "Cisco"
+        $nad.snmp_read.snmp_version | Should -Be "v1"
+        $nad.snmp_read.zone_name | Should -Be "default"
+        # community_string is always empty
+    }
+
+    It "Add Network Device with snmp v1 then change it to v2c" {
+        Add-ArubaCPNetworkDevice -name pester_SW6 -ip_address 192.0.2.6 -radius_secret MySecurePassword -vendor Cisco -snmp_version v1 -community_string myString
+        Get-ArubaCPNetworkDevice -name pester_SW6 | Set-ArubaCPNetworkDevice -snmp_version v2c -community_string myString
+        $nad = Get-ArubaCPNetworkDevice -name pester_SW6
+        $nad.name | Should -Be "pester_SW6"
+        $nad.ip_address | Should -Be "192.0.2.6"
+        $nad.vendor_name | Should -Be "Cisco"
+        $nad.snmp_read.snmp_version | Should -Be "v2c"
+        $nad.snmp_read.zone_name | Should -Be "default"
+        # community_string is always empty
+    }
+
+    AfterEach {
+        Get-ArubaCPNetworkDevice -name pester_SW6 | Remove-ArubaCPNetworkDevice -confirm:$false
+    }
+
+}
+
 AfterAll {
     Disconnect-ArubaCP -confirm:$false
 }


### PR DESCRIPTION
Allows adding network devices (nads) with SNMP parameters, and setting SNMP parameters to existing network devices (nads)